### PR TITLE
Bump Go to 1.26 (latest)

### DIFF
--- a/example/go.mod
+++ b/example/go.mod
@@ -1,6 +1,8 @@
 module github.com/mikehelmick/go-chaff/example
 
-go 1.23
+go 1.26.0
+
+toolchain go1.26.4
 
 require (
 	github.com/gorilla/handlers v1.5.2

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/mikehelmick/go-chaff
 
-go 1.23
+go 1.26.0
 
-toolchain go1.24.7
+toolchain go1.26.4
 
 require github.com/google/go-cmp v0.7.0

--- a/tracker_test.go
+++ b/tracker_test.go
@@ -350,5 +350,5 @@ func TestJSONMiddleware(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error reading response: %v", err)
 	}
-	t.Logf("%s", string(dat))
+	t.Log(string(dat))
 }

--- a/tracker_test.go
+++ b/tracker_test.go
@@ -350,5 +350,5 @@ func TestJSONMiddleware(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error reading response: %v", err)
 	}
-	t.Logf(string(dat))
+	t.Logf("%s", string(dat))
 }


### PR DESCRIPTION
## Summary

Bumps the project to the latest Go release.

- `go` directive `1.23` → `1.26.0` and `toolchain` `go1.24.7` → `go1.26.4` (latest stable), in both the library and the `example` module.
- Go 1.26's stricter `go vet` flagged a pre-existing non-constant format string in a test (`t.Logf(string(dat))`); fixed it to keep `go vet` clean.

CI already builds against `go-version: 'stable'` (from #6), so no workflow change is needed.

## Testing

Verified under the real go1.26.4 toolchain:
- `go build ./...`, `go vet ./...`, `gofmt -l .` (clean), `go test -race ./...` all pass.
- The `example` module builds and vets cleanly.

https://claude.ai/code/session_013xxDMKcDcWGNHPqpsaCS9N

---
_Generated by [Claude Code](https://claude.ai/code/session_013xxDMKcDcWGNHPqpsaCS9N)_